### PR TITLE
feat(`adapter-cloudflare`): add `options.externalDependencies` to extend ESBuild configuration

### DIFF
--- a/.changeset/spicy-lobsters-crash.md
+++ b/.changeset/spicy-lobsters-crash.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/adapter-cloudflare': minor
+---
+
+Cloudflare Adapter gets a new option `externalDependencies` which extends the list of dependencies marked as 'external' by ESBuild 'build' process

--- a/packages/adapter-cloudflare/index.d.ts
+++ b/packages/adapter-cloudflare/index.d.ts
@@ -30,6 +30,10 @@ export interface AdapterOptions {
 		 */
 		exclude?: string[];
 	};
+	/**
+ 	* Extends the list of dependencies marked as 'external' by ESBuild 'build' process
+	*/
+	externalDependencies?: string[];
 }
 
 export interface RoutesJSONSpec {

--- a/packages/adapter-cloudflare/index.js
+++ b/packages/adapter-cloudflare/index.js
@@ -58,7 +58,7 @@ export default function (options = {}) {
 				loader: {
 					'.wasm': 'copy'
 				},
-				external: ['cloudflare:*']
+				external: ['cloudflare:*', ...(options.externalDependencies || [])]
 			});
 		}
 	};


### PR DESCRIPTION
# 📖 Description

Extends the list of dependencies marked as `external` by ESBuild `'build'` process when using `Cloudflare Adapter`.

# 📖 Context
Relates to: https://github.com/sveltejs/kit/issues/10028

When integrating [MSW](https://mswjs.io/) with a SvelteKit project using Cloudflare Adapter, I get the following error:

```bash
> playwright test

[WebServer]
[WebServer] compilerOptions.css as a boolean is deprecated. Use 'external' instead of false.
[WebServer]
[WebServer] .svelte-kit/generated/client-optimized/app.js (26:27) "handleError" is not exported by "src/hooks.client.ts", imported by ".svelte-kit/generated/client-optimized/app.js".
[WebServer] ✘ [ERROR] Could not resolve "msw/node"

    .svelte-kit/output/server/chunks/node.js:1:28:
      1 │ import { setupServer } from "msw/node";
        ╵                             ~~~~~~~~~~

  The path "./node" is not exported by package "msw":

    node_modules/msw/package.json:8:13:
      8 │   "exports": {
        ╵              ^

  The file "./lib/node/index.mjs" is exported at path "./node":

    node_modules/msw/package.json:26:16:
      26 │       "import": "./lib/node/index.mjs",
         ╵                 ~~~~~~~~~~~~~~~~~~~~~~

  Import from "msw/node" to get the file "node_modules/msw/lib/node/index.mjs":

    .svelte-kit/output/server/chunks/node.js:1:28:
      1 │ import { setupServer } from "msw/node";
        │                             ~~~~~~~~~~
        ╵                             "msw/node"

  You can mark the path "msw/node" as external to exclude it from the bundle, which will remove this error.

[WebServer] error during build:
Error: Build failed with 1 error:
.svelte-kit/output/server/chunks/node.js:1:28: ERROR: Could not resolve "msw/node"
    at failureErrorWithLog (/Users/XXX/dev/XXX/XXX/node_modules/.pnpm/esbuild@0.18.11/node_modules/esbuild/lib/main.js:1639:15)
    at /Users/XXX/dev/XXX/XXX/node_modules/.pnpm/esbuild@0.18.11/node_modules/esbuild/lib/main.js:1051:25
    at /Users/XXX/dev/XXX/XXX/node_modules/.pnpm/esbuild@0.18.11/node_modules/esbuild/lib/main.js:996:52
    at buildResponseToResult (/Users/XXX/dev/XXX/XXX/node_modules/.pnpm/esbuild@0.18.11/node_modules/esbuild/lib/main.js:1049:7)
    at /Users/XXX/dev/XXX/XXX/node_modules/.pnpm/esbuild@0.18.11/node_modules/esbuild/lib/main.js:1078:16
    at responseCallbacks.<computed> (/Users/XXX/dev/XXX/XXX/node_modules/.pnpm/esbuild@0.18.11/node_modules/esbuild/lib/main.js:700:9)
    at handleIncomingPacket (/Users/XXX/dev/XXX/XXX/node_modules/.pnpm/esbuild@0.18.11/node_modules/esbuild/lib/main.js:755:9)
    at Socket.readFromStdout (/Users/XXX/dev/XXX/XXX/node_modules/.pnpm/esbuild@0.18.11/node_modules/esbuild/lib/main.js:676:7)
    at Socket.emit (node:events:513:28)
    at addChunk (node:internal/streams/readable:324:12)
Error: Process from config.webServer was not able to start. Exit code: 1
```

Considering I plan to use this in a test environment but I don't want to conditionally load the adapter for production only, I think it makes sense to open the door to users to be able to mark other dependencies as external to plug to this adapter internal ESBuild config.

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:
- [x] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [x] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
- [x] Run the tests with `pnpm test` and lint the project with `pnpm lint` and `pnpm check`

### Changesets
- [x] If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
